### PR TITLE
change recipe to avoid conflicts

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -142,10 +142,11 @@ local function register_air_tank(name, desc, color, uses, material)
 	minetest.register_craft({
 		recipe = {
 			{"", material, ""},
-			{material, "", material},
+			{material, "airtanks:compressor", material},
 			{"", material, ""},
 		},
-		output = "airtanks:empty_"..name.."_tank"
+		output = "airtanks:empty_"..name.."_tank",
+		replacements = {{"airtanks:compressor", "airtanks:compressor"}},
 	})
 	
 end


### PR DESCRIPTION
Added the compressor to the middle of the recipe in order to avoid conflict with xindustrial (diamond or mese mold or something) and another mod we were trying out. (The name escapes me at the moment.)

Replacements makes it so the compressor is not consumed in the making of the empty air tank.