### PR TITLE
Recharge a single empty tank replaces stack with single full tank.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -57,9 +57,15 @@ local function recharge_airtank(itemstack, user, pointed_thing, full_item)
 			itemstack:set_wear(0)
 		else
 			local inv = user:get_inventory()
-			local leftover = inv:add_item("main", full_item)
-			if leftover:get_count() == 0 then
-				itemstack:set_count(itemstack:get_count()-1)
+			local tanks_in_stack = itemstack:get_count();
+
+			if tanks_in_stack == 1 then
+				itemstack = ItemStack(full_item) -- replace with new stack containing one full tank
+			else
+				local leftover = inv:add_item("main", full_item)
+				if leftover:get_count() == 0 then
+					itemstack:set_count(itemstack:get_count()-1)
+				end
 			end
 		end
 		minetest.sound_play("airtanks_compressor", {pos = pointed_thing.under, gain = 0.5})
@@ -248,3 +254,4 @@ local function player_event_handler(player, eventname)
 end
 
 minetest.register_playerevent(player_event_handler)
+

--- a/init.lua
+++ b/init.lua
@@ -57,14 +57,13 @@ local function recharge_airtank(itemstack, user, pointed_thing, full_item)
 			itemstack:set_wear(0)
 		else
 			local inv = user:get_inventory()
-			local tanks_in_stack = itemstack:get_count();
 
-			if tanks_in_stack == 1 then
+			if itemstack:get_count() == 1 then
 				itemstack = ItemStack(full_item) -- replace with new stack containing one full tank
 			else
 				local leftover = inv:add_item("main", full_item)
 				if leftover:get_count() == 0 then
-					itemstack:set_count(itemstack:get_count()-1)
+					itemstack:take_item(1)
 				end
 			end
 		end


### PR DESCRIPTION
It bugged me that I couldn't fill a single tank without having an extra space free in my inventory, so this suggested fix checks if the empty-tank is the only item in the stack, and if so replaces it with the full tank.